### PR TITLE
updated for Markdig 0.7

### DIFF
--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -18,9 +18,10 @@ $testsiteFolder = "$currentPath\testsite"
 $pluginsFolder = "$testsiteFolder\_plugins"
 $postsFolder = "$testsiteFolder\_posts"
 $testGeneratedFile = "$testsiteFolder\_site\2015\11\06\MarkdigTest.html"
+$pretzelPath = "C:\tools\Pretzel\pretzel"
 
 If (-Not (Test-Path $testsiteFolder)){
-    & "C:\tools\Pretzel\pretzel" create testsite
+    & $pretzelPath create testsite
 
     if ($LASTEXITCODE -ne 0) 
     {
@@ -66,7 +67,7 @@ Start-Sleep -milliseconds 100
 Add-Type -assembly "system.io.compression.filesystem"
 [io.compression.zipfile]::ExtractToDirectory("$currentPath/artifacts/MarkdigEngine.zip", $pluginsFolder)
 
-& "C:\tools\Pretzel\pretzel" bake testsite --debug
+& $pretzelPath bake testsite --debug
 
 if ($LASTEXITCODE -ne 0) 
 {
@@ -93,7 +94,7 @@ function AssertFileContains
 }
 
 # table test
-AssertFileContains $testGeneratedFile "<table class=""table"">"
+AssertFileContains $testGeneratedFile "<table>"
 
 # smiley test
 AssertFileContains $testGeneratedFile "😃"

--- a/src/MarkdigEngine.csx
+++ b/src/MarkdigEngine.csx
@@ -9,7 +9,7 @@ public sealed class MarkdigEngine : ILightweightMarkupEngine
 
     public MarkdigEngine()
     {
-        _pipeline = new MarkdownPipelineBuilder().UseAllExtensions().UseEmojiAndSmiley().Build();
+        _pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseEmojiAndSmiley().Build();
     }
 
     public string Convert(string markdownContent)


### PR DESCRIPTION
- updated for Markdig 0.7 (`UseAllExtensions` was renamed to `UseAdvancedExtensions`, see https://github.com/lunet-io/markdig/commit/d43947af45b61e555bf6ca44032e4a55d68eb0f6)
- tables don't have an explicit class anymore

BTW, thanks for this plugin, it's much better than my [MarkdownIt plugin](https://github.com/thoemmi/Pretzel.MarkdownIt).
